### PR TITLE
print lisp form instead of internal representation

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -278,7 +278,7 @@ eval env xobj@(XObj o i t) = do
               Right ok -> return (Right (last ok))
        [] -> return dynamicNil
        x ->
-         return (evalError ctx ("I did not understand the form `" ++ show x ++ "`.") (info xobj))
+         return (evalError ctx ("I did not understand the form `" ++ pretty xobj ++ "`") (info xobj))
     force x = seq x x
     checkArity params args =
       let la = length args


### PR DESCRIPTION
When invalid syntax is reached, print out offending form instead of the internal representation.

Instead of printing out
``` clojure
> (fn <> [form] form)
I did not understand the form `XObj {obj = Lst [XObj {obj = Fn Nothing (fromList []), info = Just (Info {infoLine = 1, infoColumn = 2, infoFile = "REPL", infoDelete = fromList [], infoIdentifier = 0}), ty = Nothing},XObj {obj = Sym <> Symbol, info = Just (Info {infoLine = 1, infoColumn = 5, infoFile = "REPL", infoDelete = fromList [], infoIdentifier = 0}), ty = Nothing},XObj {obj = Arr [XObj {obj = Sym form Symbol, info = Just (Info {infoLine = 1, infoColumn = 9, infoFile = "REPL", infoDelete = fromList [], infoIdentifier = 0}), ty = Nothing}], info = Just (Info {infoLine = 1, infoColumn = 8, infoFile = "REPL", infoDelete = fromList [], infoIdentifier = 0}), ty = Nothing},XObj {obj = Sym form Symbol, info = Just (Info {infoLine = 1, infoColumn = 15, infoFile = "REPL", infoDelete = fromList [], infoIdentifier = 0}), ty = Nothing}], info = Just (Info {infoLine = 1, infoColumn = 1, infoFile = "REPL", infoDelete = fromList [], infoIdentifier = 0}), ty = Nothing}`.
```
Print the following instead.
```
> (fn <> [form] form)
I did not understand the form `(fn <> <> [form] form)` at line 1, column 1 in 'REPL'.
```
This isn't perfect because it doesn't print the exact input form, but it is better than it was.